### PR TITLE
Feature v2/moving logic outside app

### DIFF
--- a/v2/src/clients/RollbarClient.ts
+++ b/v2/src/clients/RollbarClient.ts
@@ -1,0 +1,18 @@
+import Rollbar, { Configuration as RollbarCOnfiguration } from 'rollbar';
+import settings from 'settings';
+
+const rollbarConfig: RollbarCOnfiguration = {
+  accessToken: '<accessToken>',
+  environment: settings.environment,
+  enabled: true,
+  autoInstrument: true,
+  captureUsername: true,
+  captureEmail: true,
+  captureIp: true,
+  captureUncaught: true,
+  captureUnhandledRejections: true,
+};
+
+const RollbarClient = new Rollbar(rollbarConfig);
+
+export default RollbarClient;

--- a/v2/src/components/Account.tsx
+++ b/v2/src/components/Account.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import LoginIcon from '@mui/icons-material/Login';
@@ -7,86 +7,79 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import BottomButton from './BottomButton';
 import Auth, { AuthenticationError } from '../libs/auth';
 
+const CHROME_AUTHENTICATE = () => chrome.runtime.sendMessage({ action: 'authenticate' });
+
+const CHROME_SIGNOUT = () => chrome.runtime.sendMessage({ action: 'signout' });
+
 export default function Account() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isSessionExpired, setIsSessionExpired] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
 
-  const handleAuthentication = () => {
-    chrome.runtime.sendMessage({ action: 'authenticate' });
-  };
-
   const handleSignOut = () => {
     setIsAuthenticated(false);
     setUserEmail(null);
-
-    chrome.runtime.sendMessage({ action: 'signout' });
+    CHROME_SIGNOUT();
   };
 
-  useEffect(
-    () => {
-      const auth = new Auth();
-      auth.load()
-        .then(() => {
-          if (auth.isAuthenticated) {
-            setIsAuthenticated(auth.isAuthenticated);
-            setUserEmail(auth.email);
-          }
+  useEffect(() => {
+    const auth = new Auth();
+    auth
+      .load()
+      .then(() => {
+        if (auth.isAuthenticated) {
+          setIsAuthenticated(auth.isAuthenticated);
+          setUserEmail(auth.email);
+        }
 
-          if (auth.isSessionExpired()) {
-            setIsSessionExpired(true);
-          }
-        })
-        .catch((error) => {
-          if (error instanceof AuthenticationError && error.message === 'Cannot find tokens in storage') {
-            // Skip when tokens cannot be found
-          } else {
-            throw error;
-          }
-        });
-    },
-    [],
-  );
+        if (auth.isSessionExpired()) {
+          setIsSessionExpired(true);
+        }
+      })
+      .catch((error) => {
+        if (
+          error instanceof AuthenticationError && error.message === 'Cannot find tokens in storage'
+        ) {
+          // Skip when tokens cannot be found
+        } else {
+          throw error;
+        }
+      });
+  }, []);
+
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
-    <Box sx={{
-      my: 4,
-      width: '100%',
-      textAlign: 'center',
-    }}
+    <Box
+      sx={{
+        my: 4,
+        width: '100%',
+        textAlign: 'center',
+      }}
     >
-      {
-        !isAuthenticated
-          ? null
-          : (
-            <Fragment>
-              <Typography variant='h5'>Welcome!</Typography>
-              <br />
-              <Typography variant='subtitle2'>You are logged in as</Typography>
-              <Typography variant='subtitle1'>{userEmail}</Typography>
-              <br />
-              {
-                !isSessionExpired
-                  ? null
-                  : (
-                    <Typography variant='body2'>Your session has expired. Please make sure to log in to refresh your session.</Typography>
-                  )
-              }
-              <BottomButton variant='contained' onClick={handleSignOut} startIcon={<LogoutIcon />} sx={{ my: 2 }}>
-                Sign out
-              </BottomButton>
-            </Fragment>
-          )
-      }
-      {
-        isAuthenticated && !isSessionExpired
-          ? null
-          : (
-            <BottomButton variant='contained' onClick={handleAuthentication} startIcon={<LoginIcon />} sx={{ my: 2 }}>
-              Log in or Sign up
-            </BottomButton>
-          )
-      }
+      <Typography variant='h5'>Welcome!</Typography>
+      <br />
+      <Typography variant='subtitle2'>You are logged in as</Typography>
+      <Typography variant='subtitle1'>{userEmail}</Typography>
+      <br />
+
+      {isSessionExpired && (
+        <Typography variant='body2'>
+          Your session has expired. Please make sure to log in to refresh
+          your session.
+        </Typography>
+      )}
+
+      <BottomButton
+        variant='contained'
+        onClick={isSessionExpired ? CHROME_AUTHENTICATE : handleSignOut}
+        startIcon={isSessionExpired ? <LoginIcon /> : <LogoutIcon />}
+        sx={{ my: 2 }}
+      >
+        {isSessionExpired ? 'Log in or Sign up' : 'Sign out'}
+      </BottomButton>
     </Box>
   );
 }

--- a/v2/src/components/Account.tsx
+++ b/v2/src/components/Account.tsx
@@ -48,7 +48,16 @@ export default function Account() {
   }, []);
 
   if (!isAuthenticated) {
-    return null;
+    return (
+      <BottomButton
+        variant='contained'
+        onClick={CHROME_AUTHENTICATE}
+        startIcon={<LoginIcon />}
+        sx={{ my: 2 }}
+      >
+        Log in or Sign up
+      </BottomButton>
+    );
   }
 
   return (

--- a/v2/src/components/App.test.tsx
+++ b/v2/src/components/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/v2/src/components/App.tsx
+++ b/v2/src/components/App.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import Rollbar, { Configuration as RollbarCOnfiguration } from 'rollbar';
 import { Provider as RollbarProvider, ErrorBoundary } from '@rollbar/react';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
-// import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import HomeIcon from '@mui/icons-material/Home';
+
+import RollbarClient from 'clients/RollbarClient';
 
 import settings from '../settings';
 
@@ -16,22 +16,8 @@ import Upload from './Upload';
 import Account from './Account';
 
 export default function App() {
-  const rollbarConfig: RollbarCOnfiguration = {
-    accessToken: '<accessToken>',
-    environment: settings.environment,
-    enabled: true,
-    autoInstrument: true,
-    captureUsername: true,
-    captureEmail: true,
-    captureIp: true,
-    captureUncaught: true,
-    captureUnhandledRejections: true,
-  };
-
-  const rollbar = new Rollbar(rollbarConfig);
-
   return (
-    <RollbarProvider instance={rollbar}>
+    <RollbarProvider instance={RollbarClient}>
       {/*
         TODO
         fallbackUI

--- a/v2/tsconfig.json
+++ b/v2/tsconfig.json
@@ -21,7 +21,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "src",
   },
   "include": [
     "src"


### PR DESCRIPTION
# Changes: 

* Moving out constant logic from render logic
Example: Rollback config inside App component

* Making import absolute inside src
Instead of of importing things using '../../settings' we can start from the src folder 'settings'

* A lot of unnecessary ternary logic inside Account.tsx
Example:

```js
{isSessionExpired ? null  : (
    <Typography variant='body2'>
        Your session has expired. Please make sure to log in to refresh
        your session.
    </Typography>
)}

// could be only this:

{isSessionExpired &&  (
    <Typography variant='body2'>
        Your session has expired. Please make sure to log in to refresh
        your session.
    </Typography>
)}
```