### PR TITLE
Do not display error if tokens have not been stored yet

### DIFF
--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Auth from 'libs/auth';
+import Auth, { AuthenticationError } from 'libs/auth';
+import log from 'libs/log';
 
 type Action =
   | { type: 'SIGN_IN'; payload: { email: string } }
@@ -66,7 +67,11 @@ function AuthProvider({ children }: AuthProviderProps) {
         if (auth.isSessionExpired()) dispatch({ type: 'SESSION_EXPIRED' });
       })
       .catch((error) => {
-        console.error('Auth Error:', error);
+        if (error instanceof AuthenticationError && error.message.match(/Cannot find tokens in storage/i)) {
+          // Skip as it means tokens have not been requested and stored yet
+        } else {
+          log.warn('Authentication Error', {}, error);
+        }
       });
   }, []);
 


### PR DESCRIPTION
- Fix error message displayed in the extension page `chrome://extensions` when tokens are not stored yet, e.g. when user signed out.
- Second error not solved yet.

<img width="739" alt="image" src="https://user-images.githubusercontent.com/40524083/165844811-7720aa84-7b68-40fe-af4a-fea4deb5463d.png">

