### PR TITLE
Get shareable link from backend

### DIFF
--- a/src/clients/SugarShareClient.ts
+++ b/src/clients/SugarShareClient.ts
@@ -13,6 +13,7 @@ interface PresignedUrlBody {
 interface PresignedUrlResponse {
   uuid: string;
   presignedUrl: string;
+  shareableLink: string;
 }
 
 class SugarShareClient {
@@ -81,8 +82,12 @@ class SugarShareClient {
    * Upload file and return a shareable link
    */
   public async upload(file: File, handleProgress: Callback<number>): Promise<string> {
-    const { presignedUrl } = await this.getPresignedUrl(file);
+    const { presignedUrl, shareableLink } = await this.getPresignedUrl(file);
     await this.putFile(file, presignedUrl, handleProgress);
+
+    if (shareableLink) {
+      return shareableLink;
+    }
 
     const url = new URL(presignedUrl);
     return `${url.hostname}${url.pathname}`;

--- a/src/libs/background/authenticate.ts
+++ b/src/libs/background/authenticate.ts
@@ -49,7 +49,6 @@ export default function authenticate(message: Message, sendResponse: Callback) {
     },
     async (responseUrl?: string) => {
       if (!responseUrl) {
-        // TODO
         log.error(chrome.runtime.lastError?.message ?? 'Error while launching web auth flow', { ...message });
         sendResponse('Could not authenticate');
         return;


### PR DESCRIPTION
This allows to modify the shareable link anytime in the future in case we e.g. want to use a link shortener.